### PR TITLE
Use `got` instead of `request`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var debug   = require('debug')('npm-me')
-var stats   = require('npm-stats')()
-var map     = require('map-limit')
-var request = require('request')
+var debug = require('debug')('npm-me')
+var stats = require('npm-stats')()
+var map   = require('map-limit')
+var got   = require('got')
 
 module.exports = function(user, done) {
   stats.user(user).list(function(err, list) {
@@ -32,7 +32,7 @@ module.exports = function(user, done) {
         if (!lastPublisher && !firstPublisher) return next()
 
         debug(pkg)
-        request.get('http://api.npmjs.org/downloads/point/last-month/' + pkg, function(err, res, body) {
+        got('http://api.npmjs.org/downloads/point/last-month/' + pkg, function(err, body) {
           if (err) return next(err)
 
           next(null, {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "debug": "^2.1.0",
+    "got": "^1.2.2",
     "map-limit": "0.0.1",
-    "npm-stats": "^1.0.1",
-    "request": "^2.47.0"
+    "npm-stats": "^1.0.1"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Becase `request` is huge and takes a lot of time to `require`. And since it's many features aren't used here there's no need to use it.
