### PR TITLE
Use real semver comparison to find latest.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var debug   = require('debug')('npm-me')
 var stats   = require('npm-stats')()
 var map     = require('map-limit')
 var request = require('request')
+var semver = require('semver')
 
 module.exports = function(user, done) {
   stats.user(user).list(function(err, list) {
@@ -13,10 +14,7 @@ module.exports = function(user, done) {
 
         var versions = Object.keys(data.versions)
         var latest   = versions.sort(function(a, b) {
-          return (
-              (+new Date(data.time[b]))
-            - (+new Date(data.time[a]))
-          )
+          return semver.compare(b, a)
         }).shift()
 
         if (!latest) return next()

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "debug": "^2.1.0",
     "map-limit": "0.0.1",
     "npm-stats": "^1.0.1",
-    "request": "^2.47.0"
+    "request": "^2.47.0",
+    "semver": "^4.1.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Previous method failed as some older packages did not have the .time
field.

Fixes #2.
