### PR TITLE
Ignore semver errors on packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ module.exports = function(user, done) {
 
         var versions = Object.keys(data.versions)
         var latest   = versions.sort(function(a, b) {
-          return semver.compare(b, a)
+          try {
+            return semver.compare(b, a)
+          } catch (err) {
+            return -1
+          }
         }).shift()
 
         if (!latest) return next()


### PR DESCRIPTION
With `npm-me shama` I hit:

``` shell
TypeError: Invalid Version: 0.4.0a
    at new SemVer (/usr/local/lib/node_modules/npm-me/node_modules/semver/semver.js:273:11)
    at SemVer.compare (/usr/local/lib/node_modules/npm-me/node_modules/semver/semver.js:312:13)
    at Function.compare (/usr/local/lib/node_modules/npm-me/node_modules/semver/semver.js:493:31)
    at /usr/local/lib/node_modules/npm-me/index.js:17:25
    at Array.sort (native)
    at /usr/local/lib/node_modules/npm-me/index.js:16:33
    at Request._callback (/usr/local/lib/node_modules/npm-me/node_modules/npm-stats/node_modules/nano/nano.js:291:11)
    at Request.self.callback (/usr/local/lib/node_modules/npm-me/node_modules/npm-stats/node_modules/nano/node_modules/request/index.js:142:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/lib/node_modules/npm-me/node_modules/npm-stats/node_modules/nano/node_modules/request/index.js:856:14)
```

as invalid versions were used at one point in time. This just ignores those packages. Thanks!
