### PR TITLE
Handle 0 download counts in CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ npmme(argv._[0], function(err, downloads) {
   downloads = downloads
   .filter(Boolean)
   .map(function(dl) {
-    dl.count = Number(dl.count)
+    dl.count = Number(dl.count) || 0
     return dl
   })
   .sort(function(a, b) {


### PR DESCRIPTION
If the download count for any package is 0 the CLI will fail in adding commas to numbers:
```sh
npm-me/node_modules/add-commas/index.js:7
        throw new Error('not a number');
              ^
Error: not a number
    at module.exports (npm-me/node_modules/add-commas/index.js:7:15)
    at console.log.columnify.config.count.align (npm-me/cli.js:39:15)
```